### PR TITLE
chore(bootstrap): Use class name resolution feature of PHP 5.5

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -27,18 +27,18 @@ $app = new Illuminate\Foundation\Application(
 */
 
 $app->singleton(
-    'Illuminate\Contracts\Http\Kernel',
-    'CompassHB\Www\Http\Kernel'
+    Illuminate\Contracts\Http\Kernel::class,
+    CompassHB\Www\Http\Kernel::class
 );
 
 $app->singleton(
-    'Illuminate\Contracts\Console\Kernel',
-    'CompassHB\Www\Console\Kernel'
+    Illuminate\Contracts\Console\Kernel::class,
+    CompassHB\Www\Console\Kernel::class,
 );
 
 $app->singleton(
-    'Illuminate\Contracts\Debug\ExceptionHandler',
-    'CompassHB\Www\Exceptions\Handler'
+    Illuminate\Contracts\Debug\ExceptionHandler::class,
+    CompassHB\Www\Exceptions\Handler::class
 );
 
 /*


### PR DESCRIPTION
I find this a little cleaner than using strings.
Allows us to alias the class names.