### PR TITLE
Less brittle attempt at <audio> for daily reading.

### DIFF
--- a/app/Http/Controllers/PassagesController.php
+++ b/app/Http/Controllers/PassagesController.php
@@ -33,6 +33,7 @@ class PassagesController extends Controller
         $passages = Passage::latest('published_at')->published()->take(5)->get();
         $passage = $passages->first();
         $passage->verses = $this->scripture->getScripture($passage->title);
+        $passage->audio = $this->scripture->getAudioScripture($passage->title);
 
         $postflash = '';
 

--- a/app/Repositories/Scripture/EsvScriptureRepository.php
+++ b/app/Repositories/Scripture/EsvScriptureRepository.php
@@ -6,7 +6,8 @@ use Cache;
 class EsvScriptureRepository implements ScriptureRepository
 {
     private $apikey;
-    private $options = "include-footnotes=false&audio-format=mp3";
+    private $options = "include-footnotes=false&include-audio-link=false&audio-format=mp3";
+    private $audioOptions = "output-format=mp3";
     private $url = "http://www.esvapi.org/v2/rest/passageQuery";
 
     public function __construct()
@@ -39,5 +40,10 @@ class EsvScriptureRepository implements ScriptureRepository
         });
 
         return $response;
+    }
+
+    public function getAudioScripture($passage) 
+    {
+        return $this->url."?key=".$this->apikey."&passage=".urlencode($passage)."&".$this->audioOptions;
     }
 }

--- a/app/Repositories/Scripture/ScriptureRepository.php
+++ b/app/Repositories/Scripture/ScriptureRepository.php
@@ -3,4 +3,5 @@
 interface ScriptureRepository
 {
     public function getScripture($passage);
+    public function getAudioScripture($passage);
 }

--- a/resources/views/dashboard/passages/index.blade.php
+++ b/resources/views/dashboard/passages/index.blade.php
@@ -10,53 +10,8 @@
   {{ Lang::choice('passages.daily_sessions_count', $analytics['sessions']) }}
 </p>
 
-<script>
-var DailyReading = {
-  getAudioHref: function () {
-    var as = document.getElementsByTagName('a');
-    for (var i = 0; i < as.length; i++) {
-      var href = as[i].href;
-      if (href.indexOf('esvmedia.org') != -1) {
-        return href;
-      }
-    }
-  },
-
-  getSibling: function () {
-    return document.getElementsByClassName('tk-seravek-web')[0].nextSibling.nextSibling;
-  },
-
-  getParent: function () {
-    return DailyReading.getSibling().parentNode;
-  },
-
-  insertNode: function (node) {
-    DailyReading.getParent().insertBefore(node, DailyReading.getSibling());
-  },
-
-  clearSecondTitle: function () {
-    var x = document.getElementsByTagName('h2')[0];
-    if (x != null) 
-      x.remove();
-  },
-
-  insertAudioNode: function () {
-    var audioNode = document.createElement('audio');
-    audioNode.src = DailyReading.getAudioHref();
-    audioNode.controls = 'controls';
-    DailyReading.insertNode(audioNode);
-  },
-
-  prepareReading: function () {
-    DailyReading.insertAudioNode();
-    DailyReading.clearSecondTitle();
-  }
-};
-
-DailyReading.prepareReading();
-</script>
-
   {!! $postflash !!}
+<audio src="{{ $passage->audio }}" controls="controls" />
   {!! $passage->body !!}
   {!! $passage->verses !!}
 


### PR DESCRIPTION
This is meant to eliminate the js/DOM hack in the last daily reading controls. Unfortunately, I can't run the dev environment yet (can we do that at the next tech night?).

I don't know of a robust way to eliminate the title that comes inside the <div class="esv"> that we directly write into the page inside views/dashboard/passages/index.blade.php. There is no way in the API to pass a query param to eliminate it. I vote taking out the additional title and just styling it with CSS.

I added the getAudioScripture to the interface because I figure we'll always need this from our bible content for accessibility reasons alone.